### PR TITLE
Support synonyms for assessed biomarker entity

### DIFF
--- a/data_dictionary/v0.3/data_dictionary.json
+++ b/data_dictionary/v0.3/data_dictionary.json
@@ -26,22 +26,54 @@
                         "requirement": true
                     },
                     "example": [
-                        "presence of rs1800562 mutation"
+                        "increased IL6 level"
                     ],
                     "pattern": "^.+$",
                     "pattern_notes": "Matches on an entire line, regardless of content, not including an empty line."
                 },
                 "assessed_biomarker_entity": {
-                    "description": "Biomarker entity and common name/gene symbol/short name.",
-                    "type": "string",
+                    "description": "Data for the assessed biomarker entity.",
+                    "type": "object",
                     "required": {
                         "requirement": true
                     },
-                    "example": [
-                        "rs1800562 mutation in hereditary haemochromatosis protein (hereditary hemochromatosis protein) (HFE)"
-                    ],
-                    "pattern": "^.+$",
-                    "pattern_notes": "Matches on an entire line, regardless of content, not including an empty line."
+                    "properties": {
+                        "recommended_name": {
+                            "description": "The recommended name for the assessed biomarker entity.",
+                            "type": "string",
+                            "required": {
+                                "requirement": true 
+                            },
+                            "example": [
+                                "Interleukin-6 (IL6)"
+                            ],
+                            "pattern": "^.+$",
+                            "pattern_notes": "Matches on an entire line, regardless of content, not including an empty line."
+                        },
+                        "synonyms": {
+                            "description": "List of synonyms the assessed biomarker entity might have.",
+                            "type": "array",
+                            "required": {
+                                "requirement": false
+                            },
+                            "items": [
+                                {
+                                    "synonym": {
+                                        "description": "A single synonym for the assessed biomarker identity.",
+                                        "type": "string",
+                                        "required": {
+                                            "requirement": false
+                                        },
+                                        "example": [
+                                            "CDF"
+                                        ],
+                                        "pattern": "^.*$",
+                                        "pattern_notes": "Matches on an entire line, regardless of content, including an empty line."
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "assessed_biomarker_entity_id": {
                     "description": "Accession or identifier that matches the biomarker term.",

--- a/supplementary_files/sample_data_model_structures/v0.3/sample_structure.json
+++ b/supplementary_files/sample_data_model_structures/v0.3/sample_structure.json
@@ -2,7 +2,8 @@
     "biomarker_id": "",
     "biomarker_component": [
         {
-            "biomarker": {
+            "biomarker": "",
+            "assessed_biomarker_entity": {
                 "recommended_name": "",
                 "synonyms": [
                     {
@@ -10,7 +11,6 @@
                     }
                 ]
             },
-            "assessed_biomarker_entity": "",
             "assessed_biomarker_entity_id": "",
             "assessed_entity_type": "",
             "specimen": [


### PR DESCRIPTION
Assessed_biomarker_entity is now an object to support a recommended name and synonyms. This will allow for more robust searching and filtering by end users in the future. 